### PR TITLE
Upgrade jacoco-maven-plugin and adjust configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,25 +49,40 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.7</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>report</id>
-						<phase>test</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
+				<plugin>
+      <groupId>org.jacoco</groupId>
+      <artifactId>jacoco-maven-plugin</artifactId>
+      <version>0.8.11</version> <!-- latest stable -->
+      <executions>
+        <execution>
+          <goals>
+            <goal>prepare-agent</goal>
+          </goals>
+        </execution>
+        <execution>
+          <id>report</id>
+          <phase>verify</phase>
+          <goals>
+            <goal>report</goal>
+          </goals>
+        </execution>
+      </executions>
+      <configuration>
+        <excludes>
+          <exclude>java/*</exclude>
+          <exclude>javax/*</exclude>
+          <exclude>jdk/*</exclude>
+        </excludes>
+      </configuration>
+    </plugin>
+     plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-surefire-plugin</artifactId>
+      <version>3.2.5</version>
+    </plugin>
+  </plugins>
+</build>
+
 	</build>
 	<dependencies>
 


### PR DESCRIPTION
Updated jacoco-maven-plugin to version 0.8.11 and modified execution phase to 'verify'. Added configuration to exclude certain packages from coverage.